### PR TITLE
Update renderers.py

### DIFF
--- a/rest_framework_excel/renderers.py
+++ b/rest_framework_excel/renderers.py
@@ -34,7 +34,7 @@ class ExcelRenderer(BaseRenderer):
 
         stream = StringIO()
 
-        wb = Workbook(encoding="UTF-8")
+        wb = Workbook()
         ws = wb.active
 
         table = self.tablize(data)


### PR DESCRIPTION
remove initial encoding, which is already set in Workbook init.